### PR TITLE
response to_list; fix when payload is already resolved record

### DIFF
--- a/lib/elixir_senml/resolver.ex
+++ b/lib/elixir_senml/resolver.ex
@@ -21,7 +21,8 @@ defmodule ElixirSenml.Resolver do
   def start_resolve(payload) do
     Poison.decode!(payload, as: [%Record{}])
     |> resolve()
-    |> get_list_resolved_records()    
+    |> get_list_resolved_records()
+    |> MapSet.to_list()    
   end
 
   def get_list_resolved_records(resolver), do: resolver.resolved
@@ -112,6 +113,7 @@ defmodule ElixirSenml.Resolver do
   def resolve_unit(_, %{u: u}), do: {:ok, u}
   def resolve_unit(_, _), do: {:ok, nil}
 
+  def resolve_time(%{bt: nil}, %{t: t}), do: {:ok, t}
   def resolve_time(%{bt: bt}, %{t: t}), do: {:ok, t+bt}
   def resolve_time(%{bt: bt}, _), do: {:ok, bt}
   def resolve_time(_, %{t: t}), do: {:ok, t}


### PR DESCRIPTION
Resolve response as a list instead MapSet

## Description

Added the following line to the `start_resolve` function
`    |> MapSet.to_list() `

Added the following line to the `resolve_time` funtion
`def resolve_time(%{bt: nil}, %{t: t}), do: {:ok, t}`
The reason is that when you provide a senml payload that is already resolved then it fails on the resolve funtions since they are initialized with nil.


## Motivation and Context
See above 

## How Has This Been Tested?

mix test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
